### PR TITLE
Decode Data with NullSignature

### DIFF
--- a/ndn/data.go
+++ b/ndn/data.go
@@ -108,7 +108,7 @@ func DecodeData(wire *tlv.Block, shouldValidateSignature bool) (*Data, error) {
 		}
 	}
 
-	if d.name == nil || d.sigInfo == nil || len(d.sigValue) == 0 {
+	if d.name == nil || d.sigInfo == nil || d.sigValue == nil {
 		return nil, errors.New("Data missing required field")
 	}
 

--- a/ndn/data_test.go
+++ b/ndn/data_test.go
@@ -86,6 +86,22 @@ func TestDataDecodeNoSigValidation(t *testing.T) {
 	assert.True(t, d.HasWire())
 }
 
+func TestDataDecodeNullSignature(t *testing.T) {
+	b := tlv.NewBlock(tlv.Data, []byte{
+		tlv.Name, 0x03, tlv.GenericNameComponent, 0x01, 0x41,
+		tlv.SignatureInfo, 0x03, tlv.SignatureType, 0x01, 0xc8,
+		tlv.SignatureValue, 0x00})
+	d, err := ndn.DecodeData(b, true)
+	assert.NotNil(t, d)
+	assert.NoError(t, err)
+	assert.True(t, d.HasWire())
+
+	assert.Equal(t, "/A", d.Name().String())
+	assert.Equal(t, security.SignatureType(200), d.SignatureInfo().Type())
+	assert.NotNil(t, d.SignatureValue())
+	assert.Len(t, d.SignatureValue(), 0)
+}
+
 func TestDataDecodeUnsupportedSigType(t *testing.T) {
 	b := tlv.NewBlock(tlv.Data, []byte{
 		tlv.Name, 0x0f, tlv.GenericNameComponent, 0x02, 0x67, 0x6f, tlv.GenericNameComponent, 0x03, 0x6e, 0x64, 0x6e, tlv.GenericNameComponent, 0x04, 0x32, 0x30, 0x32, 0x30,
@@ -96,6 +112,15 @@ func TestDataDecodeUnsupportedSigType(t *testing.T) {
 		tlv.Content, 0x04, 0x01, 0x02, 0x03, 0x04,
 		tlv.SignatureInfo, 0x03, tlv.SignatureType, 0x01, 0x01,
 		tlv.SignatureValue, 0x20, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00})
+	d, err := ndn.DecodeData(b, true)
+	assert.Nil(t, d)
+	assert.Error(t, err)
+}
+
+func TestDataDecodeMissingSigValue(t *testing.T) {
+	b := tlv.NewBlock(tlv.Data, []byte{
+		tlv.Name, 0x03, tlv.GenericNameComponent, 0x01, 0x41,
+		tlv.SignatureInfo, 0x03, tlv.SignatureType, 0x01, 0xc8})
 	d, err := ndn.DecodeData(b, true)
 	assert.Nil(t, d)
 	assert.Error(t, err)

--- a/ndn/security/signature.go
+++ b/ndn/security/signature.go
@@ -20,6 +20,7 @@ const (
 	SignatureSha256WithRsaType   SignatureType = 1
 	SignatureSha256WithEcdsaType SignatureType = 3
 	SignatureHmacWithSha256Type  SignatureType = 4
+	SignatureNullType            SignatureType = 200
 )
 
 // Signer represents an implementation of a signature type.
@@ -44,6 +45,8 @@ func Sign(signatureType SignatureType, buffer []byte) ([]byte, error) {
 		return nil, errors.New("cannot sign SignatureSha256WithEcdsaType")
 	case SignatureHmacWithSha256Type:
 		return nil, errors.New("cannot sign SignatureHmacWithSha256Type")
+	case SignatureNullType:
+		return []byte{}, nil
 	default:
 		return nil, errors.New("unknown SignatureType")
 	}
@@ -61,6 +64,8 @@ func Verify(signatureType SignatureType, buffer []byte, signature []byte) (bool,
 		return false, errors.New("cannot validate SignatureSha256WithEcdsaType")
 	case SignatureHmacWithSha256Type:
 		return false, errors.New("cannot validate SignatureHmacWithSha256Type")
+	case SignatureNullType:
+		return true, nil
 	default:
 		// Unknown SignatureType
 		return false, errors.New("unknown SignatureType")


### PR DESCRIPTION
Spec: https://redmine.named-data.net/projects/ndn-tlv/wiki/NullSignature

With this patch, YaNFD and NDN-DPDK will become interoperable. Hope you'll accept.