### PR TITLE
Allow building without cgo

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,29 @@
+---
+name: build
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        os: ['ubuntu-20.04', 'windows-2019', 'macos-10.15']
+      fail-fast: false
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/setup-go@v2
+        with:
+          go-version: "^1.16"
+      - uses: actions/checkout@v2
+      - name: build without cgo
+        run: make
+        env:
+          CGO_ENABLED: 0
+      - name: install cgo dependencies (Linux)
+        run: sudo apt-get install libpcap-dev
+        if: ${{ matrix.os == 'ubuntu-20.04' }}
+      - name: build with cgo
+        run: make
+        env:
+          CGO_ENABLED: 1

--- a/face/impl/pcap.go
+++ b/face/impl/pcap.go
@@ -1,0 +1,21 @@
+/* YaNFD - Yet another NDN Forwarding Daemon
+ *
+ * Copyright (C) 2020-2021 Eric Newberry.
+ *
+ * This file is licensed under the terms of the MIT License, as found in LICENSE.md.
+ */
+
+package impl
+
+import (
+	"github.com/google/gopacket"
+	"github.com/google/gopacket/layers"
+)
+
+// PcapHandle contains a subset of *pcap.Handle methods.
+type PcapHandle interface {
+	gopacket.PacketDataSource
+	LinkType() layers.LinkType
+	WritePacketData(data []byte) error
+	Close()
+}

--- a/face/impl/pcap_disabled.go
+++ b/face/impl/pcap_disabled.go
@@ -1,0 +1,22 @@
+// +build !windows,!cgo
+
+/* YaNFD - Yet another NDN Forwarding Daemon
+ *
+ * Copyright (C) 2020-2021 Eric Newberry.
+ *
+ * This file is licensed under the terms of the MIT License, as found in LICENSE.md.
+ */
+
+package impl
+
+import (
+	"errors"
+
+	"github.com/eric135/YaNFD/core"
+)
+
+// OpenPcap returns an error on unsupported platform.
+func OpenPcap(device, bpfFilter string) (PcapHandle, error) {
+	core.LogError("Face-Pcap", "PCAP not supported on this platform")
+	return nil, errors.New("pcap not supported on this platform")
+}

--- a/face/impl/pcap_enabled.go
+++ b/face/impl/pcap_enabled.go
@@ -1,0 +1,72 @@
+// +build windows cgo
+
+/* YaNFD - Yet another NDN Forwarding Daemon
+ *
+ * Copyright (C) 2020-2021 Eric Newberry.
+ *
+ * This file is licensed under the terms of the MIT License, as found in LICENSE.md.
+ */
+
+package impl
+
+import (
+	"github.com/eric135/YaNFD/core"
+	"github.com/eric135/YaNFD/ndn/tlv"
+	"github.com/google/gopacket/layers"
+	"github.com/google/gopacket/pcap"
+)
+
+// OpenPcap creates and activates a PCAP handle.
+func OpenPcap(device, bpfFilter string) (PcapHandle, error) {
+	// Set up inactive PCAP handle
+	inactive, err := pcap.NewInactiveHandle(device)
+	if err != nil {
+		core.LogError("Face-Pcap", "Unable to create PCAP handle: ", err)
+		return nil, err
+	}
+	defer inactive.CleanUp()
+
+	// Set snap length (max amount of frame to capture)
+	if err := inactive.SetSnapLen(18 + tlv.MaxNDNPacketSize); err != nil {
+		core.LogError("Face-Pcap", "Unable to set PCAP snap length: ", err)
+		return nil, err
+	}
+
+	// Enable immediate mode
+	if err := inactive.SetImmediateMode(true); err != nil {
+		core.LogError("Face-Pcap", "Unable to set immediate mode for PCAP capture: ", err)
+		return nil, err
+	}
+
+	// Set PCAP buffer size to 24 MB
+	if err := inactive.SetBufferSize(24 * 1024 * 1024); err != nil {
+		core.LogError("Face-Pcap", "Unable to set buffer size for PCAP capture: ", err)
+		return nil, err
+	}
+
+	// Activate PCAP handle
+	hdl, err := inactive.Activate()
+	if err != nil {
+		core.LogError("Face-Pcap", "Unable to activate PCAP handle: ", err)
+		return nil, err
+	}
+
+	// Set PCAP direction to in
+	if err := hdl.SetDirection(pcap.DirectionIn); err != nil {
+		core.LogError("Face-Pcap", "Unable to set direction for PCAP handle: ", err)
+		return nil, err
+	}
+
+	// Set PCAP data link type to EN10MB
+	if err := hdl.SetLinkType(layers.LinkTypeEthernet); err != nil {
+		core.LogError("Face-Pcap", "Unable to set data link type for PCAP handle: ", err)
+		return nil, err
+	}
+
+	// Set PCAP filter (string based on NFD's formatting string)
+	if err := hdl.SetBPFFilter(bpfFilter); err != nil {
+		core.LogError("Face-Pcap", "Unable to set PCAP filter: ", err)
+	}
+
+	return hdl, nil
+}

--- a/face/impl/syscalls_darwin.go
+++ b/face/impl/syscalls_darwin.go
@@ -1,4 +1,5 @@
 // +build darwin
+
 /* YaNFD - Yet another NDN Forwarding Daemon
  *
  * Copyright (C) 2020-2021 Eric Newberry.
@@ -9,7 +10,6 @@
 package impl
 
 import (
-	"strconv"
 	"syscall"
 
 	"github.com/eric135/YaNFD/core"
@@ -17,7 +17,7 @@ import (
 )
 
 // SyscallGetSocketSendQueueSize returns the current size of the send queue on the specified socket.
-func SyscallGetSocketSendQueueSizea(c syscall.RawConn) uint64 {
+func SyscallGetSocketSendQueueSize(c syscall.RawConn) uint64 {
 	var val int
 	c.Control(func(fd uintptr) {
 		var err error

--- a/face/impl/syscalls_windows.go
+++ b/face/impl/syscalls_windows.go
@@ -25,7 +25,7 @@ func SyscallReuseAddr(network string, address string, c syscall.RawConn) error {
 }
 
 // SyscallGetSocketSendQueueSize returns the current size of the send queue on the specified socket.
-func SyscallGetSocketSendQueueSize(fd int) uint64 {
+func SyscallGetSocketSendQueueSize(c syscall.RawConn) uint64 {
 	// Unsupported at the moment
 	// TODO: See if this is possible on windows
 	return 0


### PR DESCRIPTION
It is sometimes desirable to build with cgo disabled, so that the result binary is cross platform.
For example, a non-cgo binary built for Linux would work on any Linux distribute, as it has no dependency on C libraries such as libpcap.
Moreover, a non-cgo binary can be packaged as a minimal-size Docker image that only contains the binary itself and nothing else.