### PR TITLE
Implement TCP Unicast Face Logic

### DIFF
--- a/face/init.go
+++ b/face/init.go
@@ -44,6 +44,12 @@ var udp6MulticastAddress string
 // udpLifetime is the lifetime of on-demand UDP faces after they become idle.
 var udpLifetime time.Duration
 
+// TCPUnicastPort is the standard unicast TCP port for NDN.
+var TCPUnicastPort uint16
+
+// tcpLifetime is the lifetime of on-demand UDP faces after they become idle.
+var tcpLifetime time.Duration
+
 // UnixSocketPath is the standard Unix socket file path for NDN.
 var UnixSocketPath string
 
@@ -55,9 +61,11 @@ func Configure() {
 	ndnEtherType = core.GetConfigIntDefault("faces.ethernet.ethertype", 0x8624)
 	EthernetMulticastAddress = core.GetConfigStringDefault("faces.ethernet.multicast_address", "01:00:5e:00:17:aa")
 	UDPUnicastPort = core.GetConfigUint16Default("faces.udp.port_unicast", 6363)
+	TCPUnicastPort = core.GetConfigUint16Default("faces.tcp.port_unicast", 6363)
 	UDPMulticastPort = core.GetConfigUint16Default("faces.udp.port_multicast", 56363)
 	udp4MulticastAddress = core.GetConfigStringDefault("faces.udp.multicast_address_ipv4", "224.0.23.170")
 	udp6MulticastAddress = core.GetConfigStringDefault("faces.udp.multicast_address_ipv6", "ff02::114")
 	udpLifetime = time.Duration(core.GetConfigUint16Default("faces.udp.lifetime", 600)) * time.Second
+	tcpLifetime = time.Duration(core.GetConfigUint16Default("faces.tcp.lifetime", 600)) * time.Second
 	UnixSocketPath = os.ExpandEnv(core.GetConfigStringDefault("faces.unix.socket_path", "/run/nfd.sock"))
 }

--- a/face/init.go
+++ b/face/init.go
@@ -47,7 +47,7 @@ var udpLifetime time.Duration
 // TCPUnicastPort is the standard unicast TCP port for NDN.
 var TCPUnicastPort uint16
 
-// tcpLifetime is the lifetime of on-demand UDP faces after they become idle.
+// tcpLifetime is the lifetime of on-demand TCP faces after they become idle.
 var tcpLifetime time.Duration
 
 // UnixSocketPath is the standard Unix socket file path for NDN.

--- a/face/unicast-tcp-transport.go
+++ b/face/unicast-tcp-transport.go
@@ -32,8 +32,6 @@ type UnicastTCPTransport struct {
 // MakeUnicastTCPTransport creates a new unicast TCP transport.
 func MakeUnicastTCPTransport(remoteURI *ndn.URI, localURI *ndn.URI, persistency Persistency) (*UnicastTCPTransport, error) {
 	// Validate URIs.
-	// TODO: The integration for this elsewhere is lacking.
-	//       We still need to add tcp4/tcp6 URI schemes.
 	if !remoteURI.IsCanonical() ||
 		(remoteURI.Scheme() != "tcp4" && remoteURI.Scheme() != "tcp6") ||
 		(localURI != nil && !localURI.IsCanonical()) ||
@@ -44,12 +42,6 @@ func MakeUnicastTCPTransport(remoteURI *ndn.URI, localURI *ndn.URI, persistency 
 	t := new(UnicastTCPTransport)
 	// All persistencies are accepted.
 	t.makeTransportBase(remoteURI, localURI, persistency, ndn.NonLocal, ndn.PointToPoint, tlv.MaxNDNPacketSize)
-	// TODO: TCP connections are persistent, and can be explicitly closed
-	//       (unlike UDP). Is the expiration time field only relevant to the
-	//       UDP interface, then? I see the Ethernet Multicast code doesn't
-	//       seem to use expiration time.
-	// For now, let's add a lifetime to every TCP connection as well.
-	// Verify with Eric.
 	t.expirationTime = new(time.Time)
 	*t.expirationTime = time.Now().Add(tcpLifetime)
 
@@ -99,9 +91,6 @@ func (t *UnicastTCPTransport) String() string {
 
 // SetPersistency changes the persistency of the face.
 func (t *UnicastTCPTransport) SetPersistency(persistency Persistency) bool {
-	// TODO: Ask Eric why he does this. Is this to avoid some endianness issue,
-	// or maybe there a copy by value problem? Maybe he's planning to change
-	// the persistency val later? are assignments really expensive in go?
 	if persistency == t.persistency {
 		return true
 	}

--- a/face/unicast-tcp-transport.go
+++ b/face/unicast-tcp-transport.go
@@ -1,0 +1,232 @@
+/* YaNFD - Yet another NDN Forwarding Daemon
+ *
+ * Copyright (C) 2020-2021 Eric Newberry.
+ *
+ * This file is licensed under the terms of the MIT License, as found in LICENSE.md.
+ */
+
+package face
+
+import (
+	"errors"
+	"net"
+	"strconv"
+	"time"
+
+	"github.com/named-data/YaNFD/core"
+	"github.com/named-data/YaNFD/face/impl"
+	"github.com/named-data/YaNFD/ndn"
+	"github.com/named-data/YaNFD/ndn/tlv"
+)
+
+// UnicastTCPTransport is a unicast TCP transport.
+type UnicastTCPTransport struct {
+	dialer     *net.Dialer
+	conn       *net.TCPConn
+	localAddr  net.TCPAddr
+	remoteAddr net.TCPAddr
+	transportBase
+}
+
+// MakeUnicastTCPTransport creates a new unicast TCP transport.
+func MakeUnicastTCPTransport(remoteURI *ndn.URI, localURI *ndn.URI, persistency Persistency) (*UnicastTCPTransport, error) {
+	// Validate URIs.
+	// TODO: The integration for this elsewhere is lacking.
+	//       We still need to add tcp4/tcp6 URI schemes.
+	if !remoteURI.IsCanonical() ||
+		(remoteURI.Scheme() != "tcp4" && remoteURI.Scheme() != "tcp6") ||
+		(localURI != nil && !localURI.IsCanonical()) ||
+		(localURI != nil && remoteURI.Scheme() != localURI.Scheme()) {
+		return nil, core.ErrNotCanonical
+	}
+
+	t := new(UnicastTCPTransport)
+	// All persistencies are accepted.
+	t.makeTransportBase(remoteURI, localURI, persistency, ndn.NonLocal, ndn.PointToPoint, tlv.MaxNDNPacketSize)
+	// TODO: TCP connections are persistent, and can be explicitly closed
+	//       (unlike UDP). Is the expiration time field only relevant to the
+	//       UDP interface, then? I see the Ethernet Multicast code doesn't
+	//       seem to use expiration time.
+	// For now, let's add a lifetime to every TCP connection as well. Verify
+	// with Eric.
+	t.expirationTime = new(time.Time)
+	*t.expirationTime = time.Now().Add(tcpLifetime)
+
+	// Set scope
+	ip := net.ParseIP(remoteURI.Path())
+	if ip.IsLoopback() {
+		t.scope = ndn.Local
+	} else {
+		t.scope = ndn.NonLocal
+	}
+
+	// Set local and remote addresses
+	if localURI != nil {
+		t.localAddr.IP = net.ParseIP(localURI.Path())
+		t.localAddr.Port = int(localURI.Port())
+	} else {
+		t.localAddr.Port = int(TCPUnicastPort)
+	}
+	t.remoteAddr.IP = net.ParseIP(remoteURI.Path())
+	t.remoteAddr.Port = int(remoteURI.Port())
+
+	// Attempt to "dial" remote URI
+	var err error
+	// Configure dialer so we can allow address reuse
+	t.dialer = &net.Dialer{LocalAddr: &t.localAddr, Control: impl.SyscallReuseAddr}
+	conn, err := t.dialer.Dial(t.remoteURI.Scheme(), net.JoinHostPort(t.remoteURI.Path(), strconv.Itoa(int(t.remoteURI.Port()))))
+	if err != nil {
+		return nil, errors.New("Unable to connect to remote endpoint: " + err.Error())
+	}
+	t.conn = conn.(*net.TCPConn)
+
+	if localURI == nil {
+		t.localAddr = *t.conn.LocalAddr().(*net.TCPAddr)
+		t.localURI = ndn.DecodeURIString("tcp://" + t.localAddr.String())
+	}
+
+	t.changeState(ndn.Up)
+
+	go t.expirationHandler()
+
+	return t, nil
+}
+
+func (t *UnicastTCPTransport) String() string {
+	return "UnicastTCPTransport, FaceID=" + strconv.FormatUint(t.faceID, 10) + ", RemoteURI=" + t.remoteURI.String() + ", LocalURI=" + t.localURI.String()
+}
+
+// SetPersistency changes the persistency of the face.
+func (t *UnicastTCPTransport) SetPersistency(persistency Persistency) bool {
+	// TODO: Ask Eric why he does this. Is this to avoid some endianness issue,
+	// or maybe there a copy by value problem? Maybe he's planning to change
+	// the persistency val later? are assignments really expensive in go?
+	if persistency == t.persistency {
+		return true
+	}
+
+	t.persistency = persistency
+	return true
+}
+
+// GetSendQueueSize returns the current size of the send queue.
+func (t *UnicastTCPTransport) GetSendQueueSize() uint64 {
+	rawConn, err := t.conn.SyscallConn()
+	if err != nil {
+		core.LogWarn(t, "Unable to get raw connection to get socket length: ", err)
+	}
+	return impl.SyscallGetSocketSendQueueSize(rawConn)
+}
+
+func (t *UnicastTCPTransport) onTransportFailure(fromReceive bool) {
+	switch t.persistency {
+	case PersistencyPermanent:
+		// Restart socket
+		t.conn.Close()
+		var err error
+		conn, err := t.dialer.Dial(t.remoteURI.Scheme(), net.JoinHostPort(t.remoteURI.Path(), strconv.Itoa(int(t.remoteURI.Port()))))
+		if err != nil {
+			core.LogError(t, "Unable to connect to remote endpoint: ", err)
+		}
+		t.conn = conn.(*net.TCPConn)
+
+		if fromReceive {
+			t.runReceive()
+		} else {
+			// Old receive thread will error out, so we need to replace it
+			go t.runReceive()
+		}
+	default:
+		t.changeState(ndn.Down)
+	}
+}
+
+// expirationHandler checks if the face should expire (if on demand)
+func (t *UnicastTCPTransport) expirationHandler() {
+	for {
+		time.Sleep(time.Duration(10) * time.Second)
+		if t.state == ndn.Down {
+			break
+		}
+		if t.persistency == PersistencyOnDemand && (t.expirationTime.Before(time.Now()) || t.expirationTime.Equal(time.Now())) {
+			core.LogInfo(t, "Face expired")
+			t.changeState(ndn.Down)
+			break
+		}
+	}
+}
+
+// TODO: Everything before this point has been vetted by Yash.
+// Still gotta do everything after.
+
+/*
+func (t *UnicastUDPTransport) sendFrame(frame []byte) {
+	if len(frame) > t.MTU() {
+		core.LogWarn(t, "Attempted to send frame larger than MTU - DROP")
+		return
+	}
+
+	core.LogDebug(t, "Sending frame of size ", len(frame))
+	_, err := t.conn.Write(frame)
+	if err != nil {
+		core.LogWarn(t, "Unable to send on socket - DROP")
+		t.onTransportFailure(false)
+		return
+	}
+	t.nOutBytes += uint64(len(frame))
+	*t.expirationTime = time.Now().Add(udpLifetime)
+}
+
+func (t *UnicastUDPTransport) runReceive() {
+	if lockThreadsToCores {
+		runtime.LockOSThread()
+	}
+
+	recvBuf := make([]byte, tlv.MaxNDNPacketSize)
+	for {
+		readSize, err := t.conn.Read(recvBuf)
+		if err != nil {
+			if err.Error() == "EOF" {
+				core.LogDebug(t, "EOF")
+			} else {
+				core.LogWarn(t, "Unable to read from socket (", err, ") - DROP")
+				t.onTransportFailure(true)
+			}
+			break
+		}
+
+		core.LogTrace(t, "Receive of size ", readSize)
+		t.nInBytes += uint64(readSize)
+		*t.expirationTime = time.Now().Add(udpLifetime)
+
+		if readSize > tlv.MaxNDNPacketSize {
+			core.LogWarn(t, "Received too much data without valid TLV block - DROP")
+			continue
+		}
+
+		// Send up to link service
+		t.linkService.handleIncomingFrame(recvBuf[:readSize])
+	}
+}
+
+*/
+
+func (t *UnicastTCPTransport) changeState(new ndn.State) {
+	if t.state == new {
+		return
+	}
+
+	core.LogInfo(t, "state: ", t.state, " -> ", new)
+	t.state = new
+
+	if t.state != ndn.Up {
+		core.LogInfo(t, "Closing TCP socket")
+		t.hasQuit <- true
+		t.conn.Close()
+
+		// Stop link service
+		t.linkService.tellTransportQuit()
+
+		FaceTable.Remove(t.faceID)
+	}
+}

--- a/ndn/uri.go
+++ b/ndn/uri.go
@@ -19,7 +19,7 @@ import (
 )
 
 // URIType represents the type of the URI.
-type uriType int
+type URIType int
 
 //const uriPattern = `^([0-9A-Za-z]+)://([0-9A-Za-z:-\[\]%\.]+)(:([0-9]+))?$``
 const devPattern = `^(?P<scheme>dev)://(?P<ifname>[A-Za-z0-9\-]+)$`
@@ -31,19 +31,20 @@ const udpPattern = `^(?P<scheme>udp[46]?)://\[?(?P<host>[0-9A-Za-z\:\.\-]+)(%(?P
 const unixPattern = `^(?P<scheme>unix)://(?P<path>[/\\A-Za-z0-9\:\.\-_]+)$`
 
 const (
-	unknownURI  uriType = iota
-	devURI      uriType = iota
-	ethernetURI uriType = iota
-	fdURI       uriType = iota
-	internalURI uriType = iota
-	nullURI     uriType = iota
-	udpURI      uriType = iota
-	unixURI     uriType = iota
+	unknownURI  URIType = iota
+	devURI      URIType = iota
+	ethernetURI URIType = iota
+	fdURI       URIType = iota
+	internalURI URIType = iota
+	nullURI     URIType = iota
+	udpURI      URIType = iota
+	tcpURI      URIType = iota
+	unixURI     URIType = iota
 )
 
 // URI represents a URI for a face.
 type URI struct {
-	uriType uriType
+	URIType URIType
 	scheme  string
 	path    string
 	port    uint16
@@ -52,7 +53,7 @@ type URI struct {
 // MakeDevFaceURI constucts a URI for a network interface.
 func MakeDevFaceURI(ifname string) *URI {
 	uri := new(URI)
-	uri.uriType = devURI
+	uri.URIType = devURI
 	uri.scheme = "dev"
 	uri.path = ifname
 	uri.port = 0
@@ -63,7 +64,7 @@ func MakeDevFaceURI(ifname string) *URI {
 // MakeEthernetFaceURI constructs a URI for an Ethernet face.
 func MakeEthernetFaceURI(mac net.HardwareAddr) *URI {
 	uri := new(URI)
-	uri.uriType = ethernetURI
+	uri.URIType = ethernetURI
 	uri.scheme = "ether"
 	uri.path = mac.String()
 	uri.port = 0
@@ -74,7 +75,7 @@ func MakeEthernetFaceURI(mac net.HardwareAddr) *URI {
 // MakeFDFaceURI constructs a file descriptor URI.
 func MakeFDFaceURI(fd int) *URI {
 	uri := new(URI)
-	uri.uriType = fdURI
+	uri.URIType = fdURI
 	uri.scheme = "fd"
 	uri.path = strconv.Itoa(fd)
 	uri.port = 0
@@ -85,7 +86,7 @@ func MakeFDFaceURI(fd int) *URI {
 // MakeInternalFaceURI constructs an internal face URI.
 func MakeInternalFaceURI() *URI {
 	uri := new(URI)
-	uri.uriType = internalURI
+	uri.URIType = internalURI
 	uri.scheme = "internal"
 	uri.path = ""
 	uri.port = 0
@@ -95,7 +96,7 @@ func MakeInternalFaceURI() *URI {
 // MakeNullFaceURI constructs a null face URI.
 func MakeNullFaceURI() *URI {
 	uri := new(URI)
-	uri.uriType = nullURI
+	uri.URIType = nullURI
 	uri.scheme = "null"
 	uri.path = ""
 	uri.port = 0
@@ -110,7 +111,7 @@ func MakeUDPFaceURI(ipVersion int, host string, port uint16) *URI {
 		path += "%" + zone
 	}*/
 	uri := new(URI)
-	uri.uriType = udpURI
+	uri.URIType = udpURI
 	uri.scheme = "udp" + strconv.Itoa(ipVersion)
 	uri.path = host
 	uri.port = port
@@ -121,7 +122,7 @@ func MakeUDPFaceURI(ipVersion int, host string, port uint16) *URI {
 // MakeUnixFaceURI constructs a URI for a Unix face.
 func MakeUnixFaceURI(path string) *URI {
 	uri := new(URI)
-	uri.uriType = unixURI
+	uri.URIType = unixURI
 	uri.scheme = "unix"
 	uri.path = path
 	uri.port = 0
@@ -132,7 +133,7 @@ func MakeUnixFaceURI(path string) *URI {
 // DecodeURIString decodes a URI from a string.
 func DecodeURIString(str string) *URI {
 	u := new(URI)
-	u.uriType = unknownURI
+	u.URIType = unknownURI
 	u.scheme = "unknown"
 	schemeSplit := strings.SplitN(str, ":", 2)
 	if len(schemeSplit) < 2 {
@@ -141,7 +142,7 @@ func DecodeURIString(str string) *URI {
 	}
 
 	if strings.EqualFold("dev", schemeSplit[0]) {
-		u.uriType = devURI
+		u.URIType = devURI
 		u.scheme = "dev"
 
 		regex, err := regexp.Compile(devPattern)
@@ -162,7 +163,7 @@ func DecodeURIString(str string) *URI {
 		// }
 		u.path = ifname
 	} else if strings.EqualFold("ether", schemeSplit[0]) {
-		u.uriType = ethernetURI
+		u.URIType = ethernetURI
 		u.scheme = "ether"
 
 		regex, err := regexp.Compile(ethernetPattern)
@@ -176,7 +177,7 @@ func DecodeURIString(str string) *URI {
 		}
 		u.path = matches[regex.SubexpIndex("mac")]
 	} else if strings.EqualFold("fd", schemeSplit[0]) {
-		u.uriType = fdURI
+		u.URIType = fdURI
 		u.scheme = "fd"
 
 		regex, err := regexp.Compile(fdPattern)
@@ -191,13 +192,13 @@ func DecodeURIString(str string) *URI {
 		}
 		u.path = matches[regex.SubexpIndex("fd")]
 	} else if strings.EqualFold("internal", schemeSplit[0]) {
-		u.uriType = internalURI
+		u.URIType = internalURI
 		u.scheme = "internal"
 	} else if strings.EqualFold("null", schemeSplit[0]) {
-		u.uriType = nullURI
+		u.URIType = nullURI
 		u.scheme = "null"
 	} else if strings.EqualFold("udp", schemeSplit[0]) || strings.EqualFold("udp4", schemeSplit[0]) || strings.EqualFold("udp6", schemeSplit[0]) {
-		u.uriType = udpURI
+		u.URIType = udpURI
 		u.scheme = "udp"
 
 		regex, err := regexp.Compile(udpPattern)
@@ -219,7 +220,7 @@ func DecodeURIString(str string) *URI {
 		}
 		u.port = uint16(port)
 	} else if strings.EqualFold("unix", schemeSplit[0]) {
-		u.uriType = unixURI
+		u.URIType = unixURI
 		u.scheme = "unix"
 
 		regex, err := regexp.Compile(unixPattern)
@@ -240,8 +241,8 @@ func DecodeURIString(str string) *URI {
 }
 
 // GetURIType returns the type of the face URI.
-func (u *URI) GetURIType() uriType {
-	return u.uriType
+func (u *URI) GetURIType() URIType {
+	return u.URIType
 }
 
 // Scheme returns the scheme of the face URI.
@@ -280,7 +281,7 @@ func (u *URI) Port() uint16 {
 // IsCanonical returns whether the face URI is canonical.
 func (u *URI) IsCanonical() bool {
 	// Must pass type-specific checks
-	switch u.uriType {
+	switch u.URIType {
 	case devURI:
 		return u.scheme == "dev" && u.path != "" && u.port == 0
 	case ethernetURI:
@@ -311,9 +312,9 @@ func (u *URI) IsCanonical() bool {
 
 // Canonize attempts to canonize the URI, if not already canonical.
 func (u *URI) Canonize() error {
-	if u.uriType == devURI {
+	if u.URIType == devURI {
 		// Nothing to do to canonize these
-	} else if u.uriType == ethernetURI {
+	} else if u.URIType == ethernetURI {
 		mac, err := net.ParseMAC(strings.Trim(u.path, "[]"))
 		if err != nil {
 			return core.ErrNotCanonical
@@ -321,9 +322,9 @@ func (u *URI) Canonize() error {
 		u.scheme = "ether"
 		u.path = mac.String()
 		u.port = 0
-	} else if u.uriType == fdURI {
+	} else if u.URIType == fdURI {
 		// Nothing to do to canonize these
-	} else if u.uriType == udpURI {
+	} else if u.URIType == udpURI {
 		path := u.path
 		zone := ""
 		if strings.Contains(u.path, "%") {
@@ -353,7 +354,7 @@ func (u *URI) Canonize() error {
 		} else {
 			return core.ErrNotCanonical
 		}
-	} else if u.uriType == unixURI {
+	} else if u.URIType == unixURI {
 		u.scheme = "unix"
 		testPath := "/" + u.path
 		if runtime.GOOS == "windows" {
@@ -381,20 +382,20 @@ func (u *URI) Scope() Scope {
 		return Unknown
 	}
 
-	if u.uriType == devURI {
+	if u.URIType == devURI {
 		return NonLocal
-	} else if u.uriType == ethernetURI {
+	} else if u.URIType == ethernetURI {
 		return NonLocal
-	} else if u.uriType == fdURI {
+	} else if u.URIType == fdURI {
 		return Local
-	} else if u.uriType == nullURI {
+	} else if u.URIType == nullURI {
 		return NonLocal
-	} else if u.uriType == udpURI {
+	} else if u.URIType == udpURI {
 		if net.ParseIP(u.path).IsLoopback() {
 			return Local
 		}
 		return NonLocal
-	} else if u.uriType == unixURI {
+	} else if u.URIType == unixURI {
 		return Local
 	}
 
@@ -403,17 +404,17 @@ func (u *URI) Scope() Scope {
 }
 
 func (u *URI) String() string {
-	if u.uriType == devURI {
+	if u.URIType == devURI {
 		return "dev://" + u.path
-	} else if u.uriType == ethernetURI {
+	} else if u.URIType == ethernetURI {
 		return u.scheme + "://[" + u.path + "]"
-	} else if u.uriType == fdURI {
+	} else if u.URIType == fdURI {
 		return "fd://" + u.path
-	} else if u.uriType == internalURI {
+	} else if u.URIType == internalURI {
 		return "internal://"
-	} else if u.uriType == nullURI {
+	} else if u.URIType == nullURI {
 		return "null://"
-	} else if u.uriType == udpURI {
+	} else if u.URIType == udpURI {
 		if u.scheme == "udp4" {
 			return u.scheme + "://" + u.path + ":" + strconv.FormatUint(uint64(u.port), 10)
 		} else if u.scheme == "udp6" {
@@ -421,7 +422,7 @@ func (u *URI) String() string {
 		} else {
 			return u.scheme + "://" + u.path + ":" + strconv.FormatUint(uint64(u.port), 10)
 		}
-	} else if u.uriType == unixURI {
+	} else if u.URIType == unixURI {
 		return u.scheme + "://" + u.path
 	} else {
 		return "unknown://"

--- a/ndn/uri.go
+++ b/ndn/uri.go
@@ -301,6 +301,14 @@ func (u *URI) IsCanonical() bool {
 		// We have to test whether To16() && not IPv4 because the Go net library considers IPv4 addresses to be valid IPv6 addresses
 		isIPv4, _ := regexp.MatchString(ipv4Pattern, u.PathHost())
 		return ip != nil && ((u.scheme == "udp4" && ip.To4() != nil) || (u.scheme == "udp6" && ip.To16() != nil && !isIPv4)) && u.port > 0
+	case tcpURI:
+		// Split off zone, if any
+		ip := net.ParseIP(u.PathHost())
+		// Port number is implicitly limited to <= 65535 by type uint16
+		// We have to test whether To16() && not IPv4 because the Go net library considers IPv4 addresses to be valid IPv6 addresses
+		isIPv4, _ := regexp.MatchString(ipv4Pattern, u.PathHost())
+		return ip != nil && u.port > 0 && ((u.scheme == "tcp4" && ip.To4() != nil) ||
+			(u.scheme == "tcp6" && ip.To16() != nil && !isIPv4))
 	case unixURI:
 		// Do not check whether file exists, because it may fail due to lack of priviledge in testing environment
 		return u.scheme == "unix" && u.path != "" && u.port == 0


### PR DESCRIPTION
PR Copied from `https://github.com/eric135/YaNFD/pull/1`. 

Changes: 
- In ndn/uri.go, GetURIType() would return type uriType, which wasn't visible outside the module. To make this method functional, the uriType has been renamed to URIType.
- Added Unicast TCP face to face/unicast-tcp-transport.go.
- Added associated TCP logic in ndn/uri.go.

Potentially Harmful Decisions:

- TCP is connection based, so connections can be explicitly closed (unlike UDP). This raises the question of whether to give each interface an expirationTime for TCP Unicast. I've opted to add an expiration time, with a default value of one hour. This mirrors the current settings for UDP, but not Ethernet.