### PR TITLE
face: ensure first UDP packet has incoming FaceID

### DIFF
--- a/face/udp-listener.go
+++ b/face/udp-listener.go
@@ -103,11 +103,10 @@ func (l *UDPListener) Run() {
 			core.LogError(l, "Failed to create new NDNLPv2 transport: ", err)
 			continue
 		}
-		// Pass this frame to the link service for processing
-		newLinkService.handleIncomingFrame(recvBuf[:readSize])
 
-		// Add face to table and start its thread
+		// Add face to table (which assigns FaceID) before passing current frame to link service
 		FaceTable.Add(newLinkService)
+		newLinkService.handleIncomingFrame(recvBuf[:readSize])
 		go newLinkService.Run()
 	}
 


### PR DESCRIPTION
When `UDPListener` receives a packet, it constructs LinkService, then performs these two actions:

1. The current packet is passed to LinkService, which may further pass it to forwarding.
2. The face is added to `FaceTable`, which assigns it a FaceID.

Previously, action 1 is performed before action 2.
This causes the first packet to be dropped by forwarding, with the following error message:

```
 ERROR[0002] [FwThread-0] Non-existent incoming FaceID=0 for Interest=/localhost - DROP
```

This change swaps the order, so that action 1 is performed after action 2.
This ensures FaceID is already assigned when forwarding sees the packet, so that the packet can be processed successfully.
