### PR TITLE
yanfd: disable Ethernet/Unix transports via config file

### DIFF
--- a/yanfd.toml.sample
+++ b/yanfd.toml.sample
@@ -16,6 +16,9 @@
 
   [faces.ethernet]
 
+    # Whether to enable Ethernet transports
+    enabled = true
+
     # EtherType to use for NDN
     ethertype = 0x8624
 
@@ -48,6 +51,9 @@
     port = 6363
 
   [faces.unix]
+
+    # Whether to enable Unix stream transports
+    enabled = true
 
     # Location of the socket file
     socket_path = "/run/nfd.sock"


### PR DESCRIPTION
According to README.md:

> YaNFD's configuration is split into two components: startup configuration and runtime configuration.
> Startup configuration for YaNFD is performed via a TOML file

However, the existing program does not fulfill this design: there are several command line flags that are part of the startup configuration, which existed outside of the TOML file.

This PR partially restores the design intention by deprecating `-disable-ethernet` and `-disable-unix` flags and reproducing their functionality in the TOML file.