### PR TITLE
face: fix panic in TCPListener.Close

### DIFF
--- a/face/tcp-listener.go
+++ b/face/tcp-listener.go
@@ -87,5 +87,8 @@ func (l *TCPListener) Run() {
 // Close closes the TCPListener.
 func (l *TCPListener) Close() {
 	core.LogInfo(l, "Stopping listener")
-	l.conn.Close()
+	if l.conn != nil {
+		l.conn.Close()
+		l.conn = nil
+	}
 }


### PR DESCRIPTION
Currently, if TCPListener fails to start a listening socket, its Close function may panic.
So far this condition is persistently happening on Windows for *Loopback Pseudo-Interface 1*.
The log is as follows:

```shell
$ ./yanfd.exe -config yanfd.toml.sample -disable-unix -disable-ethernet
[34m  INFO[0m[0000] [Main] Starting YaNFD    
[34m  INFO[0m[0000] [NullTransport, FaceID=0, RemoteURI=null://, LocalURI=null://] state: Down -> Up
[34m  INFO[0m[0000] [Management] Starting management
[34m  INFO[0m[0000] [InternalTransport, FaceID=0, RemoteURI=internal://, LocalURI=internal://] state: Down -> Up
[31m ERROR[0m[0000] [Main] Unable to create MulticastUDPTransport for fe80::d021:b241:d777:cb67%vEthernet (WSL) on vEthernet (WSL): Unable to create send connection to group address: dial udp [fe80::d021:b241:d777:cb67%vEthernet (WSL)]:0->:0: connect: The requested address is not valid in its context.
[34m  INFO[0m[0000] [MulticastUDPTransport, FaceID=0, RemoteURI=udp4://224.0.23.170:56363, LocalURI=udp4://172.29.144.1:56363] state: Down -> Up
[34m  INFO[0m[0000] [Main] Created multicast UDP face for 172.29.144.1 on vEthernet (WSL)
[34m  INFO[0m[0000] [Main] Created UDP listener for 172.29.144.1 on vEthernet (WSL)
[34m  INFO[0m[0000] [Main] Created TCP listener for 172.29.144.1 on vEthernet (WSL)
[34m  INFO[0m[0000] [Main] Skipping interface Local Area Connection* 12 because not up
[34m  INFO[0m[0000] [Main] Skipping interface Local Area Connection* 14 because not up
[31m ERROR[0m[0000] [Main] Unable to create MulticastUDPTransport for 2001:470:8:4cd::7%Wi-Fi on Wi-Fi: Unable to create send connection to group address: dial udp6 [2001:470:8:4cd::7%Wi-Fi]:0->[ff02::114%Wi-Fi]:56363: bind: The requested address is not valid in its context.
[31m ERROR[0m[0000] [Main] Unable to create MulticastUDPTransport for 2001:470:8:4cd:81d3:5cb1:9219:ebb6%Wi-Fi on Wi-Fi: Unable to create send connection to group address: dial udp6 [2001:470:8:4cd:81d3:5cb1:9219:ebb6%Wi-Fi]:0->[ff02::114%Wi-Fi]:56363: bind: The requested address is not valid in its context.
[31m ERROR[0m[0000] [Main] Unable to create MulticastUDPTransport for fde0:fd0a:3557:a8c7::7%Wi-Fi on Wi-Fi: Unable to create send connection to group address: dial udp6 [fde0:fd0a:3557:a8c7::7%Wi-Fi]:0->[ff02::114%Wi-Fi]:56363: bind: The requested address is not valid in its context.
[31m ERROR[0m[0000] [Main] Unable to create MulticastUDPTransport for fde0:fd0a:3557:a8c7:81d3:5cb1:9219:ebb6%Wi-Fi on Wi-Fi: Unable to create send connection to group address: dial udp6 [fde0:fd0a:3557:a8c7:81d3:5cb1:9219:ebb6%Wi-Fi]:0->[ff02::114%Wi-Fi]:56363: bind: The requested address is not valid in its context.
[31m ERROR[0m[0000] [Main] Unable to create MulticastUDPTransport for 2001:470:8:4cd:54e3:4826:30ee:6632%Wi-Fi on Wi-Fi: Unable to create send connection to group address: dial udp6 [2001:470:8:4cd:54e3:4826:30ee:6632%Wi-Fi]:0->[ff02::114%Wi-Fi]:56363: bind: The requested address is not valid in its context.
[31m ERROR[0m[0000] [Main] Unable to create MulticastUDPTransport for 2001:470:8:4cd:68bf:3dd4:da:d632%Wi-Fi on Wi-Fi: Unable to create send connection to group address: dial udp6 [2001:470:8:4cd:68bf:3dd4:da:d632%Wi-Fi]:0->[ff02::114%Wi-Fi]:56363: bind: The requested address is not valid in its context.
[31m ERROR[0m[0000] [Main] Unable to create MulticastUDPTransport for 2001:470:8:4cd:f9aa:528b:16ec:472d%Wi-Fi on Wi-Fi: Unable to create send connection to group address: dial udp6 [2001:470:8:4cd:f9aa:528b:16ec:472d%Wi-Fi]:0->[ff02::114%Wi-Fi]:56363: bind: The requested address is not valid in its context.
[31m ERROR[0m[0000] [Main] Unable to create MulticastUDPTransport for fde0:fd0a:3557:a8c7:54e3:4826:30ee:6632%Wi-Fi on Wi-Fi: Unable to create send connection to group address: dial udp6 [fde0:fd0a:3557:a8c7:54e3:4826:30ee:6632%Wi-Fi]:0->[ff02::114%Wi-Fi]:56363: bind: The requested address is not valid in its context.
[31m ERROR[0m[0000] [Main] Unable to create MulticastUDPTransport for fde0:fd0a:3557:a8c7:68bf:3dd4:da:d632%Wi-Fi on Wi-Fi: Unable to create send connection to group address: dial udp6 [fde0:fd0a:3557:a8c7:68bf:3dd4:da:d632%Wi-Fi]:0->[ff02::114%Wi-Fi]:56363: bind: The requested address is not valid in its context.
[31m ERROR[0m[0000] [Main] Unable to create MulticastUDPTransport for fde0:fd0a:3557:a8c7:f9aa:528b:16ec:472d%Wi-Fi on Wi-Fi: Unable to create send connection to group address: dial udp6 [fde0:fd0a:3557:a8c7:f9aa:528b:16ec:472d%Wi-Fi]:0->[ff02::114%Wi-Fi]:56363: bind: The requested address is not valid in its context.
[31m ERROR[0m[0000] [Main] Unable to create MulticastUDPTransport for fe80::81d3:5cb1:9219:ebb6%Wi-Fi on Wi-Fi: Unable to create receive connection for group address on Wi-Fi: listen udp6 [ff02::114%Wi-Fi]:56363: bind: The requested address is not valid in its context.
[34m  INFO[0m[0000] [MulticastUDPTransport, FaceID=0, RemoteURI=udp4://224.0.23.170:56363, LocalURI=udp4://192.168.5.7:56363] state: Down -> Up
[34m  INFO[0m[0000] [Main] Created multicast UDP face for 192.168.5.7 on Wi-Fi
[34m  INFO[0m[0000] [Main] Created UDP listener for 192.168.5.7 on Wi-Fi
[34m  INFO[0m[0000] [Main] Created TCP listener for 192.168.5.7 on Wi-Fi
[34m  INFO[0m[0000] [Main] Skipping interface Bluetooth Network Connection because not up
[34m  INFO[0m[0000] [Main] Created UDP listener for ::1%Loopback Pseudo-Interface 1 on Loopback Pseudo-Interface 1
[34m  INFO[0m[0000] [Main] Created TCP listener for ::1%Loopback Pseudo-Interface 1 on Loopback Pseudo-Interface 1
[31m ERROR[0m[0000] [UDPListener, udp6://[::1%Loopback Pseudo-Interface 1]:6363] Unable to start UDP listener: listen udp6 [::1%Loopback Pseudo-Interface 1]:6363: bind: The requested address is not valid in its context.
[34m  INFO[0m[0000] [Main] Created UDP listener for 127.0.0.1 on Loopback Pseudo-Interface 1
[31m ERROR[0m[0000] [TCPListener, tcp6://[::1%Loopback Pseudo-Interface 1]:6363] Unable to start TCP listener: listen tcp6 [::1%Loopback Pseudo-Interface 1]:6363: bind: The requested address is not valid in its context.
[34m  INFO[0m[0000] [Main] Created TCP listener for 127.0.0.1 on Loopback Pseudo-Interface 1
[34m  INFO[0m[0000] [Main] Created WebSocket listener at ws://:9696
[34m  INFO[0m[0007] [Main] Received signal interrupt - exiting
[34m  INFO[0m[0007] [WebSocketListener, ws://:9696] Stopping listener
[34m  INFO[0m[0007] [TCPListener, tcp4://172.29.144.1:6363] Stopping listener
[33m  WARN[0m[0007] [TCPListener, tcp4://172.29.144.1:6363] Unable to accept connection: accept tcp4 172.29.144.1:6363: use of closed network connection
[34m  INFO[0m[0007] [TCPListener, tcp4://192.168.5.7:6363] Stopping listener
[33m  WARN[0m[0007] [TCPListener, tcp4://192.168.5.7:6363] Unable to accept connection: accept tcp4 192.168.5.7:6363: use of closed network connection
[34m  INFO[0m[0007] [TCPListener, tcp6://[::1%Loopback Pseudo-Interface 1]:6363] Stopping listener
panic: runtime error: invalid memory address or nil pointer dereference
[signal 0xc0000005 code=0x0 addr=0x28 pc=0x11ace3f]

goroutine 1 [running]:
github.com/named-data/YaNFD/face.(*TCPListener).Close(0xc00003a720)
	C:/Users/sunny/Documents/code/YaNFD/face/tcp-listener.go:90 +0x5f
main.main()
	C:/Users/sunny/Documents/code/YaNFD/cmd/yanfd/main.go:290 +0x17a5
```

This PR prevents this panic by not trying to close `l.conn` if it is nil.