### PR TITLE
fw: don't send Interest back to inFace

### DIFF
--- a/fw/strategy.go
+++ b/fw/strategy.go
@@ -60,8 +60,8 @@ func (s *StrategyBase) GetName() *ndn.Name {
 }
 
 // SendInterest sends an Interest on the specified face.
-func (s *StrategyBase) SendInterest(interest *ndn.Interest, pitEntry *table.PitEntry, nexthop uint64, inFace uint64) {
-	s.thread.processOutgoingInterest(interest, pitEntry, nexthop, inFace)
+func (s *StrategyBase) SendInterest(interest *ndn.Interest, pitEntry *table.PitEntry, nexthop uint64, inFace uint64) bool {
+	return s.thread.processOutgoingInterest(interest, pitEntry, nexthop, inFace)
 }
 
 // SendData sends a Data packet on the specified face.


### PR DESCRIPTION
Currently, if the forwarder receives an Interest on a face that happens to be a FIB nexthop, the multicast strategy would send this Interest back to where it came from, and the best-route strategy may send it back if the FIB nexthop happens to be the lowest cost route.
This condition frequently occurs when the application is using a sync protocol.
While this would not affect application operations in a correctly implemented library, those Interests are unnecessary overhead.

This PR updates forwarding logic and strategies so that they do not send an Interest back to the incoming face, unless the face is labeled as ad hoc wireless.
