### PR TITLE
mgmt: fix face dataset Flags field

### DIFF
--- a/face/ndnlp-link-service.go
+++ b/face/ndnlp-link-service.go
@@ -1,6 +1,6 @@
 /* YaNFD - Yet another NDN Forwarding Daemon
  *
- * Copyright (C) 2020-2021 Eric Newberry.
+ * Copyright (C) 2020-2022 Eric Newberry.
  *
  * This file is licensed under the terms of the MIT License, as found in LICENSE.md.
  */
@@ -27,9 +27,9 @@ const congestionMarkOverhead = 3 + 1 + 8
 const ackOverhead = 3 + 1 + 8
 
 const (
-	FaceFlagLocalFields          uint64 = 1 << iota
-	FaceFlagLpReliabilityEnabled uint64 = 1 << iota
-	FaceFlagCongestionMarking    uint64 = 1 << iota
+	FaceFlagLocalFields = 1 << iota
+	FaceFlagLpReliabilityEnabled
+	FaceFlagCongestionMarking
 )
 
 // NDNLPLinkServiceOptions contains the settings for an NDNLPLinkService.

--- a/mgmt/face.go
+++ b/mgmt/face.go
@@ -1,6 +1,6 @@
 /* YaNFD - Yet another NDN Forwarding Daemon
  *
- * Copyright (C) 2020-2021 Eric Newberry.
+ * Copyright (C) 2020-2022 Eric Newberry.
  *
  * This file is licensed under the terms of the MIT License, as found in LICENSE.md.
  */
@@ -706,13 +706,13 @@ func (f *FaceModule) createDataset(selectedFace face.LinkService) []byte {
 		faceDataset.Flags = options.Flags()
 		if options.IsConsumerControlledForwardingEnabled {
 			// This one will only be enabled if the other two local fields are enabled (and vice versa)
-			faceDataset.Flags += 1 << 0
+			faceDataset.Flags |= face.FaceFlagLocalFields
 		}
 		if options.IsReliabilityEnabled {
-			faceDataset.Flags += 1 << 1
+			faceDataset.Flags |= face.FaceFlagLpReliabilityEnabled
 		}
 		if options.IsCongestionMarkingEnabled {
-			faceDataset.Flags += 1 << 2
+			faceDataset.Flags |= face.FaceFlagCongestionMarking
 		}
 	}
 


### PR DESCRIPTION
There was an error in `faceDataset.Flags` assignment, causing a face with *local-fields* flag (such as one created by NLSR) to instead show *lp-reliability* flag in `nfdc face` output.