### PR TITLE
mgmt: minimal cs/info dataset

### DIFF
--- a/mgmt/thread.go
+++ b/mgmt/thread.go
@@ -1,6 +1,6 @@
 /* YaNFD - Yet another NDN Forwarding Daemon
  *
- * Copyright (C) 2020-2021 Eric Newberry.
+ * Copyright (C) 2020-2022 Eric Newberry.
  *
  * This file is licensed under the terms of the MIT License, as found in LICENSE.md.
  */
@@ -38,6 +38,7 @@ func MakeMgmtThread() *Thread {
 		core.LogFatal(m, "Unable to create name for management prefix: ", err)
 	}
 	m.modules = make(map[string]Module)
+	m.registerModule("cs", new(ContentStoreModule))
 	m.registerModule("faces", new(FaceModule))
 	m.registerModule("fib", new(FIBModule))
 	m.registerModule("rib", new(RIBModule))

--- a/ndn/mgmt/cs-status.go
+++ b/ndn/mgmt/cs-status.go
@@ -1,0 +1,40 @@
+/* YaNFD - Yet another NDN Forwarding Daemon
+ *
+ * Copyright (C) 2020-2022 Eric Newberry.
+ *
+ * This file is licensed under the terms of the MIT License, as found in LICENSE.md.
+ */
+
+package mgmt
+
+import (
+	"github.com/named-data/YaNFD/ndn/tlv"
+)
+
+// CsFlag indicates a ContentStore status flag.
+type CsFlag int
+
+const (
+	CsFlagEnableAdmit CsFlag = 1 << iota
+	CsFlagEnableServe
+)
+
+// CsStatus contains status information about the Content Store.
+type CsStatus struct {
+	Capacity   uint64
+	Flags      CsFlag
+	NCsEntries uint64
+	NHits      uint64
+	NMisses    uint64
+}
+
+// Encode encodes a CsStatus.
+func (s *CsStatus) Encode() (*tlv.Block, error) {
+	wire := tlv.NewEmptyBlock(tlv.CsInfo)
+	wire.Append(tlv.EncodeNNIBlock(tlv.Capacity, s.Capacity))
+	wire.Append(tlv.EncodeNNIBlock(tlv.Flags, uint64(s.Flags)))
+	wire.Append(tlv.EncodeNNIBlock(tlv.NCsEntries, s.NCsEntries))
+	wire.Append(tlv.EncodeNNIBlock(tlv.NHits, s.NHits))
+	wire.Append(tlv.EncodeNNIBlock(tlv.NMisses, s.NMisses))
+	return wire, wire.Encode()
+}


### PR DESCRIPTION
This minimal implementation allows nfd-status-http-server to work with
YaNFD. The dataset contains valid NCsEntries counter, but other fields
are bogus.