### PR TITLE
table: RIB code cleanup & bugfix

### DIFF
--- a/table/rib.go
+++ b/table/rib.go
@@ -1,6 +1,6 @@
 /* YaNFD - Yet another NDN Forwarding Daemon
  *
- * Copyright (C) 2020-2021 Eric Newberry.
+ * Copyright (C) 2020-2022 Eric Newberry.
  *
  * This file is licensed under the terms of the MIT License, as found in LICENSE.md.
  */
@@ -14,6 +14,11 @@ import (
 	"github.com/named-data/YaNFD/ndn"
 )
 
+// RibTable represents the Routing Information Base (RIB).
+type RibTable struct {
+	RibEntry
+}
+
 // RibEntry represents an entry in the RIB table.
 type RibEntry struct {
 	component ndn.NameComponent
@@ -21,7 +26,7 @@ type RibEntry struct {
 	depth     int
 
 	parent   *RibEntry
-	children []*RibEntry
+	children map[*RibEntry]bool
 
 	routes []*Route
 }
@@ -52,19 +57,16 @@ const (
 	RouteOriginAutoconf  uint64 = 66
 )
 
-// Rib is a table containing the RIB.
-var Rib *RibEntry
-var ribPrefixes map[string]*RibEntry
-
-func init() {
-	Rib = new(RibEntry)
-	Rib.component = nil // Root component will be nil since it represents zero components
-	ribPrefixes = make(map[string]*RibEntry)
+// Rib is the Routing Information Base.
+var Rib = RibTable{
+	RibEntry: RibEntry{
+		children: map[*RibEntry]bool{},
+	},
 }
 
 func (r *RibEntry) findExactMatchEntry(name *ndn.Name) *RibEntry {
 	if name.Size() > r.depth {
-		for _, child := range r.children {
+		for child := range r.children {
 			if name.At(child.depth - 1).Equals(child.component) {
 				return child.findExactMatchEntry(name)
 			}
@@ -77,7 +79,7 @@ func (r *RibEntry) findExactMatchEntry(name *ndn.Name) *RibEntry {
 
 func (r *RibEntry) findLongestPrefixEntry(name *ndn.Name) *RibEntry {
 	if name.Size() > r.depth {
-		for _, child := range r.children {
+		for child := range r.children {
 			if name.At(child.depth - 1).Equals(child.component) {
 				return child.findLongestPrefixEntry(name)
 			}
@@ -86,95 +88,84 @@ func (r *RibEntry) findLongestPrefixEntry(name *ndn.Name) *RibEntry {
 	return r
 }
 
-func (r *RibEntry) fillTreeToPrefix(name *ndn.Name) *RibEntry {
-	curNode := r.findLongestPrefixEntry(name)
-	for depth := curNode.depth + 1; depth <= name.Size(); depth++ {
-		newNode := new(RibEntry)
-		newNode.component = name.At(depth - 1).DeepCopy()
-		newNode.depth = depth
-		newNode.parent = curNode
-		curNode.children = append(curNode.children, newNode)
-		curNode = newNode
+func (r *RibTable) fillTreeToPrefix(name *ndn.Name) *RibEntry {
+	entry := r.findLongestPrefixEntry(name)
+	for depth := entry.depth + 1; depth <= name.Size(); depth++ {
+		child := &RibEntry{
+			component: name.At(depth - 1).DeepCopy(),
+			depth:     depth,
+			parent:    entry,
+			children:  map[*RibEntry]bool{},
+		}
+		entry.children[child] = true
+		entry = child
 	}
-	return curNode
+	return entry
 }
 
 func (r *RibEntry) pruneIfEmpty() {
-	for curNode := r; curNode.parent != nil && len(curNode.children) == 0 && len(curNode.routes) == 0; curNode = curNode.parent {
+	for entry := r; entry.parent != nil && len(entry.children) == 0 && len(entry.routes) == 0; entry = entry.parent {
 		// Remove from parent's children
-		for i, child := range curNode.parent.children {
-			if child == r {
-				if i < len(curNode.parent.children)-1 {
-					copy(curNode.parent.children[i:], curNode.parent.children[i+1:])
-				}
-				curNode.parent.children = curNode.parent.children[:len(curNode.parent.children)-1]
-				break
-			}
-		}
+		delete(entry.parent.children, entry)
 	}
 }
 
-func (r *RibEntry) updateNexthops(node *RibEntry) {
-	FibStrategyTable.ClearNexthops(node.Name)
+func (r *RibEntry) updateNexthops() {
+	FibStrategyTable.ClearNexthops(r.Name)
 
 	// Find minimum cost route per nexthop
 	minCostRoutes := make(map[uint64]uint64) // FaceID -> Cost
-	for _, route := range node.routes {
-		if _, ok := minCostRoutes[route.FaceID]; !ok {
-			minCostRoutes[route.FaceID] = route.Cost
-		} else if route.Cost < minCostRoutes[route.FaceID] {
+	for _, route := range r.routes {
+		cost, ok := minCostRoutes[route.FaceID]
+		if !ok || route.Cost < cost {
 			minCostRoutes[route.FaceID] = route.Cost
 		}
 	}
 
 	// Add "flattened" set of nexthops
 	for nexthop, cost := range minCostRoutes {
-		FibStrategyTable.AddNexthop(node.Name, nexthop, cost)
+		FibStrategyTable.AddNexthop(r.Name, nexthop, cost)
 	}
 }
 
 // AddRoute adds or updates a RIB entry for the specified prefix.
-func (r *RibEntry) AddRoute(name *ndn.Name, faceID uint64, origin uint64, cost uint64, flags uint64, expirationPeriod *time.Duration) {
+func (r *RibTable) AddRoute(name *ndn.Name, faceID uint64, origin uint64, cost uint64, flags uint64, expirationPeriod *time.Duration) {
 	node := r.fillTreeToPrefix(name)
 	if node.Name == nil {
 		node.Name = name
 	}
-	var route *Route
+
+	defer node.updateNexthops()
+
 	for _, existingRoute := range node.routes {
 		if existingRoute.FaceID == faceID && existingRoute.Origin == origin {
 			existingRoute.Cost = cost
 			existingRoute.Flags = flags
 			existingRoute.ExpirationPeriod = expirationPeriod
-			route = existingRoute
-			break
+			return
 		}
 	}
 
-	if route == nil {
-		newEntry := new(Route)
-		newEntry.FaceID = faceID
-		newEntry.Origin = origin
-		newEntry.Cost = cost
-		newEntry.Flags = flags
-		newEntry.ExpirationPeriod = expirationPeriod
-		node.routes = append(node.routes, newEntry)
-		ribPrefixes[name.String()] = node
-	}
-
-	r.updateNexthops(node)
+	node.routes = append(node.routes, &Route{
+		FaceID:           faceID,
+		Origin:           origin,
+		Cost:             cost,
+		Flags:            flags,
+		ExpirationPeriod: expirationPeriod,
+	})
 }
 
-// GetAllEntries returns all routes in the FIB.
-func (r *RibEntry) GetAllEntries() []*RibEntry {
+// GetAllEntries returns all routes in the RIB.
+func (r *RibTable) GetAllEntries() []*RibEntry {
 	entries := make([]*RibEntry, 0)
 	// Walk tree in-order
 	queue := list.New()
-	queue.PushBack(r)
+	queue.PushBack(&r.RibEntry)
 	for queue.Len() > 0 {
 		ribEntry := queue.Front().Value.(*RibEntry)
 		queue.Remove(queue.Front())
 		// Add all children to stack
-		for _, child := range ribEntry.children {
+		for child := range ribEntry.children {
 			queue.PushFront(child)
 		}
 
@@ -192,7 +183,7 @@ func (r *RibEntry) GetRoutes() []*Route {
 }
 
 // RemoveRoute removes the specified route from the specified prefix.
-func (r *RibEntry) RemoveRoute(name *ndn.Name, faceID uint64, origin uint64) {
+func (r *RibTable) RemoveRoute(name *ndn.Name, faceID uint64, origin uint64) {
 	entry := r.findExactMatchEntry(name)
 	if entry != nil {
 		for i, existingRoute := range entry.routes {
@@ -204,10 +195,7 @@ func (r *RibEntry) RemoveRoute(name *ndn.Name, faceID uint64, origin uint64) {
 				break
 			}
 		}
-		if len(entry.routes) == 0 {
-			delete(ribPrefixes, name.String())
-		}
-		r.updateNexthops(entry)
+		entry.updateNexthops()
 		entry.pruneIfEmpty()
 	}
 }
@@ -215,7 +203,7 @@ func (r *RibEntry) RemoveRoute(name *ndn.Name, faceID uint64, origin uint64) {
 // CleanUpFace removes the specified face from all entries. Used for clean-up after a face is destroyed.
 func (r *RibEntry) CleanUpFace(faceId uint64) {
 	// Recursively clean children
-	for _, child := range r.children {
+	for child := range r.children {
 		child.CleanUpFace(faceId)
 	}
 
@@ -232,9 +220,6 @@ func (r *RibEntry) CleanUpFace(faceId uint64) {
 			break
 		}
 	}
-	if len(r.routes) == 0 && r.Name != nil {
-		delete(ribPrefixes, r.Name.String())
-	}
-	r.updateNexthops(r)
+	r.updateNexthops()
 	r.pruneIfEmpty()
 }


### PR DESCRIPTION
Separate the concept of `RibTable` from `RibEntry`.

Fix a logic bug in `pruneIfEmpty`.
The bug was on this line:
```go
if child == r {
```