### PR TITLE
FIB Table: Hashtable Implementation (from danningyu/YaNFD#7)

### DIFF
--- a/cmd/yanfdui/server/server.go
+++ b/cmd/yanfdui/server/server.go
@@ -121,6 +121,8 @@ type setting struct {
 	CsReplacementPolicy      string `toml:"tables.content_store.replacement_policy"`
 	DnlLifetime              int    `toml:"tables.dead_nonce_list.lifetime"`
 	RibAutoPrefixPropagation bool   `toml:"tables.rib.auto_prefix_propagation"`
+	FibTableAlgorithm        string `toml:"tables.fib.algorithm"`
+	FibTableHashTableM       uint16 `toml:"tables.fib.hashtable.m"`
 }
 
 var (

--- a/executor/yanfd.go
+++ b/executor/yanfd.go
@@ -108,6 +108,10 @@ func (y *YaNFD) Start() {
 	//core.LogInfo("Main", "Loading strategies")
 	//fw.LoadStrategies()
 
+	// Initialize FIB table
+	fibTableAlgorithm := core.GetConfigStringDefault("tables.fib.algorithm", "nametree")
+	table.CreateFIBTable(fibTableAlgorithm)
+
 	// Create null face
 	nullFace := face.MakeNullLinkService(face.MakeNullTransport())
 	face.FaceTable.Add(nullFace)

--- a/ndn/name.go
+++ b/ndn/name.go
@@ -861,6 +861,7 @@ func (n *Name) Prefix(size int) *Name {
 	}
 	// Reset wire
 	prefix.wire = new(tlv.Block)
+	prefix.cachedString = ""
 	return &prefix
 }
 

--- a/table/fib-strategy-hashtable.go
+++ b/table/fib-strategy-hashtable.go
@@ -1,0 +1,374 @@
+/* YaNFD - Yet another NDN Forwarding Daemon
+ *
+ * Copyright (C) 2022 Danning Yu.
+ *
+ * This file is licensed under the terms of the MIT License, as found in LICENSE.md.
+ */
+
+// This file implements a hash table version of the FIB, as outlined in section 2.3 of:
+// W. So, A. Narayanan and D. Oran,
+// "Named data networking on a router: Fast and DoS-resistant forwarding with hash tables,"
+// Architectures for Networking and Communications Systems, 2013, pp. 215-225,
+// doi: 10.1109/ANCS.2013.6665203.
+
+package table
+
+import (
+	"sync"
+
+	"github.com/named-data/YaNFD/ndn"
+	"github.com/named-data/YaNFD/utils/comparison"
+)
+
+type virtualDetails struct {
+	// md is the max depth associated with this virtual node, as defined in the paper.
+	md int
+}
+
+// FibStrategyHashTable represents a tree implementation of the FIB-Strategy table.
+type FibStrategyHashTable struct {
+	// m is the name length for virtual nodes, as defined in the paper
+	// Must be a positive value
+	m int
+
+	// realTable is a map of names (hashed as uint64 values) to the FIB entry
+	// associated with that name.
+	realTable map[string]*baseFibStrategyEntry
+
+	// virtTable is a map of virtual names (hashed as uint64 values) to the
+	// virtualDetails struct associated with that virtual name.
+	virtTable map[string]*virtualDetails
+
+	// virtTableNames is a map of virtual names (hashed as uint64 values) to
+	// a set of all the real names associated with that virtual name. The
+	// inner map is being used as a set; the bool value type does not matter.
+	virtTableNames map[string](map[string]struct{})
+
+	// fibStrategyRWMutex is a mutex used to synchronize accesses to the FIB,
+	// which is shared across all the forwarding threads.
+	fibStrategyRWMutex sync.RWMutex
+}
+
+// newFibStrategyTableHashTable creates a new FIB with the hash table algorithm.
+// The argument m determines the virtual name length.
+func newFibStrategyTableHashTable(m uint16) {
+	FibStrategyTable = new(FibStrategyHashTable)
+	fibStrategyTableHashTable := FibStrategyTable.(*FibStrategyHashTable)
+
+	fibStrategyTableHashTable.m = int(m) // Cast to int so that it's easy to pass to name.Prefix
+	fibStrategyTableHashTable.realTable = make(map[string]*baseFibStrategyEntry)
+	fibStrategyTableHashTable.virtTable = make(map[string]*virtualDetails)
+	fibStrategyTableHashTable.virtTableNames = make(map[string]map[string]struct{})
+
+	rootName, _ := ndn.NameFromString(("/"))
+	defaultStrategy, _ := ndn.NameFromString("/localhost/nfd/strategy/best-route/v=1")
+
+	rtEntry := new(baseFibStrategyEntry)
+	rtEntry.name = rootName
+	rtEntry.strategy = defaultStrategy
+	fibStrategyTableHashTable.realTable[rootName.String()] = rtEntry
+}
+
+// findLongestPrefixMatch returns the entry corresponding to the longest
+// prefix match of the given name. It returns nil if no exact match was found.
+func (f *FibStrategyHashTable) findLongestPrefixMatch(name *ndn.Name) *baseFibStrategyEntry {
+	if name.Size() <= f.m {
+		// Name length is less than or equal to M, so only need to check real table
+		for pfx := name.Size(); pfx >= 0; pfx-- {
+			if val, ok := f.realTable[name.Prefix(pfx).String()]; ok {
+				return val
+			}
+		}
+		return nil
+	}
+
+	// Name is longer than M, so use virtual node to lookup first
+	virtName := name.Prefix(f.m)
+	_, ok := f.virtTable[virtName.String()]
+	if ok {
+		// Virtual name present, look for longer matches
+		pfx := comparison.Min(f.virtTable[virtName.String()].md, name.Size())
+		for ; pfx > f.m; pfx-- {
+			if val, ok := f.realTable[name.Prefix(pfx).String()]; ok {
+				return val
+			}
+		}
+	}
+
+	// Name is longer that M but did not find a match for names with length > M
+	// Start looking in the real table from length M
+	// For example: Table has prefixes /a and /a/b/c, virtual entry is /a/b
+	// A search for /a/b/d will not match /a/b/c, so we need it to match /a
+	for pfx := f.m; pfx >= 0; pfx-- {
+		if val, ok := f.realTable[name.Prefix(pfx).String()]; ok {
+			return val
+		}
+	}
+
+	// no match found
+	return nil
+}
+
+// insertEntry inserts an entry into the FIB table, specifically realTable,
+// virtTable, and virtTableNames. It does not set the nexthops or strategy
+// fields of the newly created entry. The caller is responsible for doing that.
+func (f *FibStrategyHashTable) insertEntry(name *ndn.Name) *baseFibStrategyEntry {
+	nameString := name.String()
+
+	if _, ok := f.realTable[nameString]; !ok {
+		rtEntry := new(baseFibStrategyEntry)
+		rtEntry.name = name
+		f.realTable[nameString] = rtEntry
+	}
+
+	// Insert into virtual table if name size >= M
+	if name.Size() == f.m {
+		if _, ok := f.virtTable[nameString]; !ok {
+			vtEntry := new(virtualDetails)
+			vtEntry.md = name.Size()
+			f.virtTable[nameString] = vtEntry
+		}
+
+		if _, ok := f.virtTableNames[nameString]; !ok {
+			f.virtTableNames[nameString] = make(map[string]struct{})
+		}
+
+		f.virtTable[nameString].md = comparison.Max(f.virtTable[nameString].md, name.Size())
+
+		// Insert into set of names
+		f.virtTableNames[nameString][nameString] = struct{}{}
+
+	} else if name.Size() > f.m {
+		virtNameString := name.Prefix(f.m).String()
+		if _, ok := f.virtTable[virtNameString]; !ok {
+			vtEntry := new(virtualDetails)
+			vtEntry.md = name.Size()
+			f.virtTable[virtNameString] = vtEntry
+		}
+
+		if _, ok := f.virtTableNames[virtNameString]; !ok {
+			f.virtTableNames[virtNameString] = make(map[string]struct{})
+		}
+
+		f.virtTable[virtNameString].md = comparison.Max(f.virtTable[virtNameString].md, name.Size())
+
+		// Insert into set of names
+		f.virtTableNames[virtNameString][nameString] = struct{}{}
+	}
+
+	return f.realTable[nameString]
+}
+
+// pruneTables takes in an entry and removes it from the real table if it has no
+// next hops and no strategy associated with it. It also eliminates its
+// corresponding virtual entry, if applicable.
+func (f *FibStrategyHashTable) pruneTables(entry *baseFibStrategyEntry) {
+	var pruned bool
+	name := entry.name
+
+	// Delete the real entry
+	if len(entry.nexthops) == 0 && entry.strategy == nil {
+		delete(f.realTable, entry.name.String())
+		pruned = true
+	}
+
+	if !pruned {
+		return
+	}
+
+	// Delete the virtual entry too, if needed
+	if name.Size() >= f.m {
+		virtNameString := name.Prefix(f.m).String()
+		virtEntry, inVirtTable := f.virtTable[virtNameString]
+		virtTableNamesEntry, inVirtNameTable := f.virtTableNames[virtNameString]
+		namePresentForVirtName := false
+		if inVirtNameTable {
+			_, namePresentForVirtName = virtTableNamesEntry[name.String()]
+		}
+
+		// If virtual name is present in table
+		// AND real name is associated with this virtual name
+		// AND this real name was deleted from the real table
+		// Then delete from virtualTableNames if it's last real name
+		// associated with the virtual name
+		if inVirtTable && namePresentForVirtName && pruned {
+			delete(virtTableNamesEntry, name.String())
+			if len(virtTableNamesEntry) == 0 {
+				delete(f.virtTableNames, virtNameString)
+			}
+		}
+
+		// If virtual name is present in table
+		// AND the real name being deleted was the longest associated with the virtual name
+		// AND this real name was deleted from the real table
+		if inVirtTable && name.Size() == virtEntry.md && pruned {
+			_, inVirtNameTable = f.virtTableNames[virtNameString]
+			if !inVirtNameTable {
+				// Delete the entry entirely from the virtual table too
+				// if it was removed it from the virtual name table
+				delete(f.virtTable, virtNameString)
+			} else {
+				// Update with length of next longest real prefix associated
+				// with this virtual prefix
+				for k, _ := range f.virtTableNames[virtNameString] {
+					n, _ := ndn.NameFromString(k)
+					virtEntry.md = comparison.Max(virtEntry.md, n.Size())
+				}
+			}
+		}
+	}
+}
+
+// FindNextHops returns the longest-prefix matching nexthop(s) matching the specified name.
+func (f *FibStrategyHashTable) FindNextHops(name *ndn.Name) []*FibNextHopEntry {
+	f.fibStrategyRWMutex.RLock()
+	defer f.fibStrategyRWMutex.RUnlock()
+
+	entry := f.findLongestPrefixMatch(name)
+
+	if entry == nil {
+		return nil
+	}
+
+	// Go backwards to find the first entry with nexthops
+	// since some might only have a strategy but no nexthops
+	for pfx := entry.name.Size(); pfx >= 0; pfx-- {
+		val, ok := f.realTable[entry.name.Prefix(pfx).String()]
+		if ok && len(val.nexthops) > 0 {
+			return val.nexthops
+		}
+	}
+
+	return nil
+}
+
+// FindStrategy returns the longest-prefix matching strategy choice entry for the specified name.
+func (f *FibStrategyHashTable) FindStrategy(name *ndn.Name) *ndn.Name {
+	f.fibStrategyRWMutex.RLock()
+	defer f.fibStrategyRWMutex.RUnlock()
+
+	entry := f.findLongestPrefixMatch(name)
+
+	if entry == nil {
+		return nil
+	}
+
+	// Go backwards to find the first entry with strategy
+	// since some might only have a nexthops but no strategy
+	for pfx := entry.name.Size(); pfx >= 0; pfx-- {
+		val, ok := f.realTable[entry.name.Prefix(pfx).String()]
+		if ok && val.strategy != nil {
+			return val.strategy
+		}
+	}
+
+	return nil
+}
+
+// InsertNextHop adds or updates a nexthop entry for the specified prefix.
+func (f *FibStrategyHashTable) InsertNextHop(name *ndn.Name, nexthop uint64, cost uint64) {
+	f.fibStrategyRWMutex.Lock()
+	defer f.fibStrategyRWMutex.Unlock()
+
+	realEntry := f.insertEntry(name)
+
+	for _, existingNextHop := range realEntry.nexthops {
+		if existingNextHop.Nexthop == nexthop {
+			// Update existing hop
+			existingNextHop.Cost = cost
+			return
+		}
+	}
+
+	// Did not update existing hop, so add a new hop
+	nhEntry := new(FibNextHopEntry)
+	nhEntry.Nexthop = nexthop
+	nhEntry.Cost = cost
+	realEntry.nexthops = append(realEntry.nexthops, nhEntry)
+
+}
+
+// ClearNextHops clears all nexthops for the specified prefix.
+func (f *FibStrategyHashTable) ClearNextHops(name *ndn.Name) {
+	f.fibStrategyRWMutex.Lock()
+	defer f.fibStrategyRWMutex.Unlock()
+
+	entry, ok := f.realTable[name.String()]
+	if ok {
+		entry.nexthops = make([]*FibNextHopEntry, 0)
+		f.pruneTables(entry)
+	}
+}
+
+// RemoveNextHop removes the specified nexthop entry from the specified prefix.
+func (f *FibStrategyHashTable) RemoveNextHop(name *ndn.Name, nexthop uint64) {
+	f.fibStrategyRWMutex.Lock()
+	defer f.fibStrategyRWMutex.Unlock()
+
+	if _, ok := f.realTable[name.String()]; !ok {
+		return
+	}
+
+	// Remove matching nexthop from real table (if one exists)
+	realEntry := f.realTable[name.String()]
+	nextHops := realEntry.nexthops
+	for i, nh := range nextHops {
+		if nh.Nexthop == nexthop {
+			if len(nextHops) > 1 {
+				nextHops[i] = nextHops[len(nextHops)-1]
+			}
+			realEntry.nexthops = nextHops[:len(nextHops)-1]
+			f.pruneTables(realEntry)
+			break
+		}
+	}
+}
+
+// GetAllFIBEntries returns all nexthop entries in the FIB.
+func (f *FibStrategyHashTable) GetAllFIBEntries() []FibStrategyEntry {
+	f.fibStrategyRWMutex.RLock()
+	defer f.fibStrategyRWMutex.RUnlock()
+	entries := make([]FibStrategyEntry, 0)
+	for _, v := range f.realTable {
+		if len(v.nexthops) > 0 {
+			entries = append(entries, v)
+		}
+	}
+
+	return entries
+}
+
+// SetStrategy sets the strategy for the specified prefix.
+func (f *FibStrategyHashTable) SetStrategy(name *ndn.Name, strategy *ndn.Name) {
+	f.fibStrategyRWMutex.Lock()
+	defer f.fibStrategyRWMutex.Unlock()
+
+	realEntry := f.insertEntry(name)
+	realEntry.strategy = strategy
+}
+
+// UnsetStrategy unsets the strategy for the specified prefix.
+func (f *FibStrategyHashTable) UnsetStrategy(name *ndn.Name) {
+	f.fibStrategyRWMutex.Lock()
+	defer f.fibStrategyRWMutex.Unlock()
+
+	entry, ok := f.realTable[name.String()]
+	if ok {
+		entry.strategy = nil
+		f.pruneTables(entry)
+	}
+}
+
+// GetAllForwardingStrategies returns all strategy choice entries in the Strategy Table.
+func (f *FibStrategyHashTable) GetAllForwardingStrategies() []FibStrategyEntry {
+	f.fibStrategyRWMutex.RLock()
+	defer f.fibStrategyRWMutex.RUnlock()
+	entries := make([]FibStrategyEntry, 0)
+	for _, v := range f.realTable {
+		if v.strategy != nil {
+			entries = append(entries, v)
+		}
+	}
+
+	return entries
+}

--- a/table/fib-strategy-hashtable_test.go
+++ b/table/fib-strategy-hashtable_test.go
@@ -1,6 +1,6 @@
 /* YaNFD - Yet another NDN Forwarding Daemon
  *
- * Copyright (C) 2020-2021 Eric Newberry.
+ * Copyright (C) 2022 Danning Yu.
  *
  * This file is licensed under the terms of the MIT License, as found in LICENSE.md.
  */
@@ -16,8 +16,9 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestFindNextHops(t *testing.T) {
-	newFibStrategyTableTree()
+func TestFindNextHops_HT(t *testing.T) {
+	fibTableAlgorithm = "hashtable"
+	newFibStrategyTableHashTable(1)
 
 	assert.NotNil(t, FibStrategyTable)
 
@@ -69,8 +70,8 @@ func TestFindNextHops(t *testing.T) {
 	assert.Equal(t, 0, len(nexthops2c))
 }
 
-func TestFind_Set_Unset_Strategy(t *testing.T) {
-	newFibStrategyTableTree()
+func TestFind_Set_Unset_Strategy_HT(t *testing.T) {
+	newFibStrategyTableHashTable(1)
 
 	assert.NotNil(t, FibStrategyTable)
 
@@ -105,8 +106,8 @@ func TestFind_Set_Unset_Strategy(t *testing.T) {
 	assert.True(t, multicast.Equals(FibStrategyTable.FindStrategy(name3)))
 }
 
-func TestInsertNextHop(t *testing.T) {
-	newFibStrategyTableTree()
+func TestInsertNextHop_HT(t *testing.T) {
+	newFibStrategyTableHashTable(1)
 	assert.NotNil(t, FibStrategyTable)
 
 	name, _ := ndn.NameFromString("/test/name")
@@ -127,8 +128,8 @@ func TestInsertNextHop(t *testing.T) {
 	assert.Equal(t, uint64(20), nextHops[0].Cost)
 }
 
-func TestClearNextHops(t *testing.T) {
-	newFibStrategyTableTree()
+func TestClearNextHops_HT(t *testing.T) {
+	newFibStrategyTableHashTable(1)
 	assert.NotNil(t, FibStrategyTable)
 
 	name, _ := ndn.NameFromString("/test/name")
@@ -172,8 +173,8 @@ func TestClearNextHops(t *testing.T) {
 	assert.Equal(t, 1, len(nextHops))
 }
 
-func TestRemoveNextHop(t *testing.T) {
-	newFibStrategyTableTree()
+func TestRemoveNextHop_HT(t *testing.T) {
+	newFibStrategyTableHashTable(1)
 	assert.NotNil(t, FibStrategyTable)
 
 	name, _ := ndn.NameFromString("/test")
@@ -213,8 +214,8 @@ func TestRemoveNextHop(t *testing.T) {
 	assert.Equal(t, 1, len(nextHops))
 }
 
-func TestGetAllFIBEntries(t *testing.T) {
-	newFibStrategyTableTree()
+func TestGetAllFIBEntries_HT(t *testing.T) {
+	newFibStrategyTableHashTable(1)
 	assert.NotNil(t, FibStrategyTable)
 
 	bestRoute, _ := ndn.NameFromString("/localhost/nfd/strategy/best-route/v=1")
@@ -263,8 +264,8 @@ func TestGetAllFIBEntries(t *testing.T) {
 	assert.Equal(t, uint64(50), nextHops[0].Cost)
 }
 
-func TestGetAllForwardingStrategies(t *testing.T) {
-	newFibStrategyTableTree()
+func TestGetAllForwardingStrategies_HT(t *testing.T) {
+	newFibStrategyTableHashTable(1)
 	assert.NotNil(t, FibStrategyTable)
 
 	bestRoute, _ := ndn.NameFromString("/localhost/nfd/strategy/best-route/v=1")
@@ -311,4 +312,161 @@ func TestGetAllForwardingStrategies(t *testing.T) {
 	assert.True(t, multicast.Equals(fse[2].GetStrategy()))
 	nextHops = fse[2].GetNextHops()
 	assert.Equal(t, 0, len(nextHops))
+}
+
+func testFIB_HT_Details(t *testing.T, m uint16) {
+	// A test suite specific to the hash table approach
+	newFibStrategyTableHashTable(m)
+	assert.NotNil(t, FibStrategyTable)
+
+	name1, _ := ndn.NameFromString("/a")
+	name2, _ := ndn.NameFromString("/a/b/d")
+	name3, _ := ndn.NameFromString("/a/b/c")
+	name4, _ := ndn.NameFromString("/a/b/d/e")
+	name5, _ := ndn.NameFromString("/a/b/d/e/f")
+	nameNonexistent, _ := ndn.NameFromString(("/asdfasdf"))
+
+	hopId1 := uint64(10)
+	hopId2 := uint64(11)
+	hopId3 := uint64(12)
+	hopId4a := uint64(13)
+	hopId4b := uint64(14)
+	hopId5 := uint64(15)
+
+	cost := uint64(1)
+
+	FibStrategyTable.InsertNextHop(name1, hopId1, cost)
+	FibStrategyTable.InsertNextHop(name2, hopId2, cost)
+	FibStrategyTable.InsertNextHop(name3, hopId3, cost)
+	FibStrategyTable.InsertNextHop(name4, hopId4a, cost)
+	FibStrategyTable.InsertNextHop(name4, hopId4b, cost)
+	FibStrategyTable.InsertNextHop(name5, hopId5, cost)
+
+	nextHopsEmpty := FibStrategyTable.FindNextHops(nameNonexistent)
+	assert.Equal(t, 0, len(nextHopsEmpty))
+
+	nameSearch1, _ := ndn.NameFromString("/a/b/c/d/e/f")
+	// match /a/b/c
+	nextHops1 := FibStrategyTable.FindNextHops(nameSearch1)
+	assert.Equal(t, 1, len(nextHops1))
+	assert.Equal(t, hopId3, nextHops1[0].Nexthop)
+	assert.Equal(t, cost, nextHops1[0].Cost)
+
+	nameSearch2, _ := ndn.NameFromString("/a/c/d/e/f/g")
+	// match /a
+	nextHops2 := FibStrategyTable.FindNextHops(nameSearch2)
+	assert.Equal(t, 1, len(nextHops2))
+	assert.Equal(t, hopId1, nextHops2[0].Nexthop)
+	assert.Equal(t, cost, nextHops2[0].Cost)
+
+	nextHops3 := FibStrategyTable.FindNextHops(name1)
+	// match /a
+	assert.Equal(t, 1, len(nextHops3))
+	assert.Equal(t, hopId1, nextHops3[0].Nexthop)
+	assert.Equal(t, cost, nextHops3[0].Cost)
+
+	nameSearch3, _ := ndn.NameFromString("/a/b/d/e/zzz")
+	// match /a/b/d/e
+	nextHops4 := FibStrategyTable.FindNextHops(nameSearch3)
+	assert.Equal(t, 2, len(nextHops4))
+	assert.Equal(t, hopId4a, nextHops4[0].Nexthop)
+	assert.Equal(t, cost, nextHops4[0].Cost)
+	assert.Equal(t, hopId4b, nextHops4[1].Nexthop)
+	assert.Equal(t, cost, nextHops4[1].Cost)
+
+	nameSearch4, _ := ndn.NameFromString("/a/b/d/e/f/g/h")
+	// match /a/b/d/e/f
+	nextHops5 := FibStrategyTable.FindNextHops(nameSearch4)
+	assert.Equal(t, 1, len(nextHops5))
+	assert.Equal(t, hopId5, nextHops5[0].Nexthop)
+	assert.Equal(t, cost, nextHops5[0].Cost)
+
+	nameSearch5, _ := ndn.NameFromString("/b")
+	// match nothing
+	nextHops6 := FibStrategyTable.FindNextHops(nameSearch5)
+	assert.Equal(t, 0, len(nextHops6))
+
+	nameSearch6, _ := ndn.NameFromString("/z/y/x/w/v/u/t")
+	// match nothing
+	nextHops7 := FibStrategyTable.FindNextHops(nameSearch6)
+	assert.Equal(t, 0, len(nextHops7))
+
+	// Deletions
+	// Delete nonexistent name or face
+	FibStrategyTable.RemoveNextHop(nameNonexistent, uint64(0))
+	FibStrategyTable.RemoveNextHop(name1, uint64(0))
+
+	// Delete with name and outFace that exists
+	FibStrategyTable.RemoveNextHop(name4, hopId4b)
+	nextHops := FibStrategyTable.FindNextHops(name4)
+	assert.Equal(t, 1, len(nextHops))
+	assert.Equal(t, hopId4a, nextHops4[0].Nexthop)
+	assert.Equal(t, cost, nextHops4[0].Cost)
+
+	FibStrategyTable.RemoveNextHop(name4, hopId4a)
+	// This should only match name2 now: /a/b/d
+	nextHops = FibStrategyTable.FindNextHops(name4)
+	assert.Equal(t, 1, len(nextHops))
+	assert.Equal(t, hopId2, nextHops[0].Nexthop)
+	assert.Equal(t, cost, nextHops[0].Cost)
+
+	FibStrategyTable.RemoveNextHop(name3, hopId3)
+	// This should only match name1 now: /a
+	nextHops = FibStrategyTable.FindNextHops(name3)
+	assert.Equal(t, 1, len(nextHops))
+	assert.Equal(t, hopId1, nextHops[0].Nexthop)
+	assert.Equal(t, cost, nextHops[0].Cost)
+
+	// This should trigger pruning
+	FibStrategyTable.RemoveNextHop(name5, hopId5)
+	nextHops = FibStrategyTable.FindNextHops(name5)
+	// This should only match name2 now: /a/b/d
+	assert.Equal(t, 1, len(nextHops))
+	assert.Equal(t, hopId2, nextHops[0].Nexthop)
+	assert.Equal(t, cost, nextHops[0].Cost)
+
+	FibStrategyTable.RemoveNextHop(name1, hopId1)
+	nextHops = FibStrategyTable.FindNextHops(name1)
+	assert.Equal(t, 0, len(nextHops))
+
+	nextHops = FibStrategyTable.FindNextHops(name2)
+	assert.Equal(t, 1, len(nextHops))
+	assert.Equal(t, hopId2, nextHops[0].Nexthop)
+	assert.Equal(t, cost, nextHops[0].Cost)
+
+	FibStrategyTable.RemoveNextHop(name2, hopId2)
+
+	// No entries left in FIB, everything should be removed
+	nextHops = FibStrategyTable.FindNextHops(name1)
+	assert.Equal(t, 0, len(nextHops))
+	nextHops = FibStrategyTable.FindNextHops(name2)
+	assert.Equal(t, 0, len(nextHops))
+	nextHops = FibStrategyTable.FindNextHops(name3)
+	assert.Equal(t, 0, len(nextHops))
+	nextHops = FibStrategyTable.FindNextHops(name4)
+	assert.Equal(t, 0, len(nextHops))
+	nextHops = FibStrategyTable.FindNextHops(name5)
+	assert.Equal(t, 0, len(nextHops))
+
+	// Eliminate the root name from tree too
+	// This results in an empty hash table
+	rootName, _ := ndn.NameFromString("/")
+	FibStrategyTable.UnsetStrategy(rootName)
+	nextHops = FibStrategyTable.FindNextHops(name1)
+	assert.Equal(t, 0, len(nextHops))
+	nextHops = FibStrategyTable.FindNextHops(name5)
+	assert.Equal(t, 0, len(nextHops))
+	strategy := FibStrategyTable.FindStrategy(name1)
+	assert.Nil(t, strategy)
+
+	// Nexthop entry exists but not root strategy
+	FibStrategyTable.InsertNextHop(name1, hopId1, cost)
+	strategy = FibStrategyTable.FindStrategy(name1)
+	assert.Nil(t, strategy)
+}
+func TestFIB_HT_RealAndVirtualNodes(t *testing.T) {
+	// Hashtable specific tests, for different values of m
+	for i := 1; i < 8; i++ {
+		testFIB_HT_Details(t, uint16(i))
+	}
 }

--- a/table/init.go
+++ b/table/init.go
@@ -35,6 +35,10 @@ var csReplacementPolicy string
 // producerRegions contains the prefixes produced in this forwarder's region.
 var producerRegions []string
 
+// fibTableAlgorithm contains the options for how the FIB is implemented
+// Allowed values: nametree, hashtable
+var fibTableAlgorithm string
+
 // Configure configures the forwarding system.
 func Configure() {
 	tableQueueSize = core.GetConfigIntDefault("tables.queue_size", 1024)
@@ -73,4 +77,17 @@ func Configure() {
 // SetCsCapacity sets the CS capacity from management.
 func SetCsCapacity(capacity int) {
 	csCapacity = capacity
+}
+
+func CreateFIBTable(fibTableAlgorithm string) {
+	switch fibTableAlgorithm {
+	case "hashtable":
+		m := core.GetConfigUint16Default("tables.fib.hashtable.m", 5)
+		newFibStrategyTableHashTable(m)
+	case "nametree":
+		newFibStrategyTableTree()
+	default:
+		// Default to nametree
+		core.LogFatal("CreateFIBTable", "Unrecognized FIB table algorithm specified: ", fibTableAlgorithm)
+	}
 }

--- a/utils/comparison/comparison.go
+++ b/utils/comparison/comparison.go
@@ -1,0 +1,19 @@
+package comparison
+
+import "golang.org/x/exp/constraints"
+
+func Min[V constraints.Ordered](a, b V) V {
+	if a < b {
+		return a
+	} else {
+		return b
+	}
+}
+
+func Max[V constraints.Ordered](a, b V) V {
+	if a > b {
+		return a
+	} else {
+		return b
+	}
+}

--- a/yanfd.toml.sample
+++ b/yanfd.toml.sample
@@ -133,3 +133,15 @@
 
     # Enables or disables auto prefix propagation
     auto_prefix_propagation = false
+  
+  [tables.fib]
+    # Selects the algorithm used to implement the FIB
+    # Allowed options: nametree, hashtable
+    # Default: nametree
+    algorithm = "nametree"
+
+    [tables.fib.hashtable]
+    # Specifies the virtual node depth. Must be a positive number.
+    # Default is 5.
+    m = 5
+


### PR DESCRIPTION
Implement FIB table based on hash table algorithm from Won et al 2013.

A Python implementation of the algorithm can be found [here](https://gist.github.com/danningyu/8724a4b1894f15ea67cd0eb6e4db62b8) if one prefers reading code in Python to understand the algorithm first.

Unit test coverage of this new algorithm is at 100%.