### PR TITLE
Update actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,29 +1,35 @@
----
-name: build
+name: Build
 on:
   push:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   build:
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: ['ubuntu-20.04', 'windows-2019', 'macos-10.15']
+        os: [ubuntu-20.04, ubuntu-22.04,
+             macos-11, macos-12,
+             windows-2019, windows-2022]
       fail-fast: false
-    runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/setup-go@v2
+      - name: Install Go
+        uses: actions/setup-go@v3
         with:
           go-version: "^1.18"
-      - uses: actions/checkout@v2
-      - name: build without cgo
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: Build without cgo
         run: make
         env:
           CGO_ENABLED: 0
-      - name: install cgo dependencies (Linux)
-        run: sudo apt-get install libpcap-dev
-        if: ${{ matrix.os == 'ubuntu-20.04' }}
-      - name: build with cgo
+      - name: Install cgo dependencies (Linux)
+        run: sudo apt-get -qy install libpcap-dev
+        if: ${{ runner.os == 'Linux' }}
+      - name: Build with cgo
         run: make
         env:
           CGO_ENABLED: 1

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,14 +1,3 @@
-# For most projects, this workflow file will not need changing; you simply need
-# to commit it to your repository.
-#
-# You may wish to alter this file to override the set of languages analyzed,
-# or to provide custom queries or build logic.
-#
-# ******** NOTE ********
-# We have attempted to detect the languages in your repository. Please check
-# the `language` matrix defined below to confirm you have the correct set of
-# supported CodeQL languages.
-#
 name: "CodeQL"
 
 on:
@@ -33,39 +22,29 @@ jobs:
       fail-fast: false
       matrix:
         language: [ 'go' ]
-        # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python' ]
-        # Learn more:
-        # https://docs.github.com/en/free-pro-team@latest/github/finding-security-vulnerabilities-and-errors-in-your-code/configuring-code-scanning#changing-the-languages-that-are-analyzed
+        # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby' ]
+        # Use only 'java' to analyze code written in Java, Kotlin or both
+        # Use only 'javascript' to analyze code written in JavaScript, TypeScript or both
+        # Learn more about CodeQL language support at https://aka.ms/codeql-docs/language-support
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
+      uses: github/codeql-action/init@v2
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
         # By default, queries listed here will override any specified in a config file.
         # Prefix the list here with "+" to use these queries and those in the config file.
-        # queries: ./path/to/local/query, your-org/your-repo/queries@main
+        # Details on CodeQL's query packs refer to : https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
+        # queries: security-extended,security-and-quality
 
-    # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
-    # If this step fails, then you should remove it and run the build manually (see below)
+    # Autobuild attempts to build any compiled languages  (C/C++, C#, Go, or Java).
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v1
-
-    # ℹ️ Command-line programs to run using the OS shell.
-    # 📚 https://git.io/JvXDl
-
-    # ✏️ If the Autobuild fails above, remove it and uncomment the following three lines
-    #    and modify them (or add more) to build your code if your project
-    #    uses a compiled language
-
-    #- run: |
-    #   make bootstrap
-    #   make release
+      uses: github/codeql-action/autobuild@v2
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      uses: github/codeql-action/analyze@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,21 +1,24 @@
----
-name: test
-on: [push, pull_request]
+name: Test
+on:
+  push:
+  pull_request:
+
 jobs:
   test:
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         go-version: [1.18.x]
         os: [ubuntu-latest]
-    runs-on: ${{ matrix.os }}
+      fail-fast: false
     steps:
       - name: Install Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: ${{ matrix.go-version }}
       - name: Checkout repository
-        uses: actions/checkout@v2
-      - name: Go Imports Check
+        uses: actions/checkout@v3
+      - name: Go imports check
         uses: zjkmxy/golang-github-actions@v1.1.1
         with:
           run: imports
@@ -24,4 +27,3 @@ jobs:
         run: go test ./...
         env:
           CGO_ENABLED: 0
-


### PR DESCRIPTION
* bump to v3 of `actions/checkout` and `actions/setup-go` to silence [deprecation warnings](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/)
* update codeql actions to v2 ([v1 is being deprecated](https://github.blog/changelog/2022-04-27-code-scanning-deprecation-of-codeql-action-v1/)) and delete some pointless comments in the workflow file
* add `ubuntu-22.04` and `windows-2022` to build matrix
* move to `macos-11` and `macos-12` ([10.15 is no longer supported](https://github.com/actions/runner-images/issues/5583))